### PR TITLE
Swagger Spec Clarification

### DIFF
--- a/api/blueprints/users/controllers.py
+++ b/api/blueprints/users/controllers.py
@@ -96,7 +96,7 @@ def get_user_networks(user_id):
                           WHERE network_registration.id_user=%s",
                           selection_fields=[user_id],
                           args=request.args,
-                          order_clause="ORDER BY id_network DESC",
+                          order_clause="ORDER BY join_date DESC",
                           order_index_format="join_date <= %s",
                           order_arg="max_registration_date")
 

--- a/spec_swagger.yaml
+++ b/spec_swagger.yaml
@@ -89,6 +89,7 @@ paths:
             $ref: '#/definitions/User'
         '405':
           description: Invalid input
+
   '/user/{userId}/networks':
     get:
       tags:
@@ -122,7 +123,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Network'
+              $ref: '#/definitions/NetworkWithJoin'
         '405':
           description: Invalid input
   '/user/{userId}/posts':
@@ -1246,6 +1247,70 @@ definitions:
         type: string
       network_class:
         type: string
+
+  NetworkWithJoin:
+    description: |
+      A Network with the join_date of the user for which this network
+      was invoked for, e.g., the /user/{userId}/networks call.
+    type: object
+    required:
+      - id
+      - location_cur
+    properties:
+      id:
+        type: integer
+        format: bigint20
+      city_cur:
+        type: string
+      id_city_cur:
+        type: integer
+        format: bigint20
+      region_cur:
+        type: string
+      id_region_cur:
+        type: integer
+        format: bigint2
+      country_cur:
+        type: string
+      id_country_cur:
+        type: integer
+        format: bigint20
+      city_origin:
+        type: string
+      id_city_origin:
+        type: integer
+        format: bigint20
+      region_origin:
+        type: string
+      id_region_origin:
+        type: integer
+        format: bigint20
+      country_origin:
+        type: string
+      id_country_origin:
+        type: integer
+        format: bigint20
+      language_origin:
+        type: string
+      id_language_origin:
+        type: integer
+        format: bigint20
+      network_class:
+        type: string
+        description: |
+         _l - language
+          cc - city
+          rc - region
+          co - country
+      date_added:
+        type: string
+        format: timestamp
+      img_link:
+        type: string
+      twitter_query_level:
+        type: string
+      join_date:
+        format: timestamp
 
   NetworkRegistration:
     type: object


### PR DESCRIPTION
- specifies that the get-user-networks API call also inserts the `join_date` into the network objects returned, so that the API client can easily tell when a user joined a certain network. 
- additionally, fixes API bug where user networks were being returned ordered by network_id instead of by the user's join_date