### PR TITLE
if request body does not contain JSON, assume it contains form data

### DIFF
--- a/api/apiutils.py
+++ b/api/apiutils.py
@@ -106,6 +106,9 @@ def execute_put_by_id(request, table_name):
     :returns: A response object ready to return to the client
     """
     content = request.get_json()
+    if not content:
+        content = request.form
+
     columns = content.keys()
 
     if "id" not in columns:
@@ -138,6 +141,8 @@ def execute_post_by_table(request, content_fields, table_name):
     :returns: A response object ready for the client.
     """
     content = request.get_json()
+    if not content:
+        content = request.form
 
     query = "INSERT INTO %s (%s) " % (table_name, ','.join(content_fields))
     query += " values ("


### PR DESCRIPTION
Submitting directly from HTML forms without JavaScript makes it impossible to give a JSON body to a POST request.  

This PR gets around this problem by first checking (on the API server-side) if the request is a JSON.  If it is not, it will be None, so we can assume it is a form dictionary. 