### PR TITLE
Bugfixes related to automatic network creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# culturemesh-api
+# CultureMesh API
 API for CultureMesh
+
+The CultureMesh API is a [Stanford Code the Change](https://codethechange.stanford.edu/) project.

--- a/api/apiutils.py
+++ b/api/apiutils.py
@@ -139,6 +139,9 @@ def execute_post_by_table(request, content_fields, table_name):
     """
     Executes a POST command to a certain table.
 
+    This function is smart enough to detect NULLs in content fields
+    to leverage default database schema values.
+
     :param request: The request received
     :param content_fields: A tuple containing the field/column names
                      to extract from the request and insert into
@@ -146,20 +149,35 @@ def execute_post_by_table(request, content_fields, table_name):
     :param table_name: The table to insert into
     :returns: A response object ready for the client.
     """
+
     content = request.get_json()
     if not content:
         content = request.form
 
-    query = "INSERT INTO %s (%s) " % (table_name, ','.join(content_fields))
+    # Sanitize content fields.  If we 'null' or 'NULL' or '-1' for any
+    # of the fields, we exclude them from the post_by_table since they will
+    # automatically default to NULL.  We also only keep content fields
+    # that are actually in the form.
+    non_null_content_fields = []
+    for content_field in content_fields:
+      if content_field in content and \
+                    content[content_field] and \
+                    str(content[content_field]) != "-1" and \
+                    str(content[content_field]).lower().strip() != 'null':
+        non_null_content_fields.append(content_field)
+
+    query = "INSERT INTO %s (%s) " % (
+        table_name, ','.join(non_null_content_fields)
+    )
     query += " values ("
-    for _ in content_fields:
+    for _ in non_null_content_fields:
         query += "%s, "
     if query[-2] == ",":
         query = query[:-2]
     query += ");"
 
     args = []
-    for col in content_fields:
+    for col in non_null_content_fields:
         args.append(content[col])
     execute_insert(query, tuple(args))
     return make_response(query, HTTPStatus.OK)

--- a/api/blueprints/networks/controllers.py
+++ b/api/blueprints/networks/controllers.py
@@ -32,24 +32,26 @@ def make_new_network_request():
     req.form = {}
     conn = mysql.get_db()
     near_ids = request.args['near_location'].split(',')
-    index = 0
-    for singular, plural in zip(['country', 'region', 'city'], ['countries', 'regions', 'cities']):
-        req.form['id_' + singular + '_cur'] = near_ids[index]
-        req.form[singular + '_cur'] = get_column_value(conn, 'name', 'id', plural, near_ids[index])
-        index += 1
-    index = 0
+
+    for singular, plural, near_id in \
+      zip(['country', 'region', 'city'], ['countries', 'regions', 'cities'], near_ids):
+        req.form['id_%s_cur' % singular] = near_id
+        req.form['%s_cur' % singular] = get_column_value(
+          conn, 'name', 'id', plural, near_id
+        )
+
     if "from_location" in request.args:
         # To avoid a key error in execute_post_by_table, we need to set the
-        # other parmas to null
+        # other parameters to null
         req.form['id_language_origin'] = 'null'
         req.form['language_origin'] = 'null'
         from_ids = request.args['from_location'].split(',')
-        for singular, plural in zip(['country', 'region', 'city'], ['countries', 'regions', 'cities']):
-            req.form['id_' + singular + '_origin'] = from_ids[index]
-            req.form[singular + '_origin'] = get_column_value(
-              conn, 'name', 'id', plural, from_ids[index]
+        for singular, plural, from_id in \
+          zip(['country', 'region', 'city'], ['countries', 'regions', 'cities'], from_ids):
+            req.form['id_%s_origin' % singular] = from_id
+            req.form['%s_origin' % singular] = get_column_value(
+              conn, 'name', 'id', plural, from_id
             )
-            index += 1
         if near_ids[0] != -1:
             req.form['network_class'] = 'cc'
         elif near_ids[1] != -1:
@@ -58,8 +60,8 @@ def make_new_network_request():
             req.form['network_class'] = 'co'
     elif "language" in request.args:
         for singular, plural in zip(['country', 'region', 'city'], ['countries', 'regions', 'cities']):
-            req.form['id_' + singular + '_origin'] = 'null'
-            req.form[singular + '_origin'] = 'null'
+            req.form['id_%s_origin' % singular] = 'null'
+            req.form['%s_origin' % singular] = 'null'
         req.form['id_language_origin'] = get_column_value(
           conn, 'id', 'name', 'languages', request.args['language']
         )
@@ -93,7 +95,7 @@ def get_column_value(db_connection,
       "null"
     :return: name of area.
     """
-    if id == str(-1):
+    if item_id == str(-1) or str(item_id).lower() == 'null' or not item_id:
         return "null"
     cursor = db_connection.cursor()
     cursor.execute(

--- a/api/blueprints/networks/controllers.py
+++ b/api/blueprints/networks/controllers.py
@@ -3,6 +3,8 @@ from api import require_apikey
 from api.apiutils import *
 from pymysql.err import IntegrityError
 
+from api.blueprints.networks.utils import get_from_location_sql_string_end
+
 networks = Blueprint('network', __name__)
 
 @networks.route("/ping")
@@ -13,12 +15,18 @@ def test():
 
 def make_new_network_request():
     """
-    This will transform a GET /networks query to a POST /new network query by producing a "request" object with
-     the necessary request.args values for a "POST networks/new" request. Yeah, sorry it's kinda hacksy.
-    :return: The updated request object. Notice this is just a dictionary, since the actual request object
+    This will transform a GET /networks query to a POST /new network query by
+    producing a "request" object with the necessary request.args values for a
+    "POST networks/new" request. Yeah, sorry it's kinda hacksy.
+
+    :return: The updated request object. Notice this is just a dictionary,
+    since the actual request object
     is an ImmutableDict.
     """
-    # this makes req an arbitrary object so I can add attributes (like form and get_json) to it.
+
+    # this makes req an arbitrary object so I can add attributes
+    # (like form and get_json) to it.
+    # See: https://stackoverflow.com/questions/2280334
     req = type('', (), {})()
     req.form = {}
     conn = mysql.get_db()
@@ -30,13 +38,16 @@ def make_new_network_request():
         index += 1
     index = 0
     if "from_location" in request.args:
-        # To avoid a key error in execute_post_by_table, we need to set the other parmas to null
+        # To avoid a key error in execute_post_by_table, we need to set the
+        # other parmas to null
         req.form['id_language_origin'] = 'null'
         req.form['language_origin'] = 'null'
         from_ids = request.args['from_location'].split(',')
         for singular, plural in zip(['country', 'region', 'city'], ['countries', 'regions', 'cities']):
             req.form['id_' + singular + '_origin'] = from_ids[index]
-            req.form[singular + '_origin'] = get_column_value(conn, 'name', 'id', plural, from_ids[index])
+            req.form[singular + '_origin'] = get_column_value(
+              conn, 'name', 'id', plural, from_ids[index]
+            )
             index += 1
         if near_ids[0] != -1:
             req.form['network_class'] = 'cc'
@@ -48,35 +59,46 @@ def make_new_network_request():
         for singular, plural in zip(['country', 'region', 'city'], ['countries', 'regions', 'cities']):
             req.form['id_' + singular + '_origin'] = 'null'
             req.form[singular + '_origin'] = 'null'
-        req.form['id_language_origin'] = get_column_value(conn, 'id', 'name', 'languages', request.args['language'])
+        req.form['id_language_origin'] = get_column_value(
+          conn, 'id', 'name', 'languages', request.args['language']
+        )
         req.form['language_origin'] = request.args['language']
         req.form['network_class'] = '_l'
-    # To avoid an error, we will make a pseudo function that returns none so that execute_post_by_table will use the
+    # To avoid an error, we will make a pseudo function that returns none so
+    # that execute_post_by_table will use the
     # function dictionary instead.
     else:
         # This shouldn't happen: the route should handle the input params.
         abort(HTTPStatus.BAD_REQUEST)
-        
+
     def get_json():
         return None
     req.get_json = get_json
     return req
 
 
-def get_column_value(db_connection, desired_column, query_column, table_name, item_id):
+def get_column_value(db_connection,
+                     desired_column,
+                     query_column,
+                     table_name,
+                     item_id):
     """
     Fetches name from DB table given id. I also use this for languages.
     :param db_connection: Database connection (use mysql.get_db())
     :param desired_column: column you want to find out
     :param query_column: column you already know that you can use to query
     :param table_name:
-    :param item_id: value corresponding to query_column, -1 if supposed to be "null"
+    :param item_id: value corresponding to query_column, -1 if supposed to be
+      "null"
     :return: name of area.
     """
     if id == str(-1):
         return "null"
     cursor = db_connection.cursor()
-    cursor.execute("SELECT " + desired_column + " FROM " + table_name + " WHERE " + query_column + "=%s", item_id)
+    cursor.execute(
+      "SELECT " + desired_column + " FROM " + table_name + " WHERE " + query_column + "=%s",
+      item_id
+    )
     cursor.close()
     return cursor.fetchone()
 
@@ -86,39 +108,57 @@ def get_column_value(db_connection, desired_column, query_column, table_name, it
 def get_networks(func_counter=0):
     # Validate that we have valid input data (we need a near_location).
     if "near_location" not in request.args:
-        return make_response("No near_location specified", HTTPStatus.METHOD_NOT_ALLOWED)
-    near_ids = request.args["near_location"].split(",")
+        return make_response(
+          "No near_location specified", HTTPStatus.METHOD_NOT_ALLOWED
+        )
+
+    location_ids = []
+
     # All requests will start with the same query and query for near_location.
-    mysql_string_start = "SELECT * \
-                          FROM networks \
-                          WHERE id_country_cur=%s AND id_region_cur=%s AND id_city_cur=%s"
-    # Need to check if querying a location or language network. That changes our queries.
+    my_sql_string_start, near_location_ids = get_near_location_sql_string_start(
+      request.args["near_location"]
+    )
+
+    location_ids.extend(near_location_ids)
+
+    # Need to check if querying a location or language network.
+    # That changes our queries.
     if "from_location" in request.args:
-        near_ids.extend(request.args["from_location"].split(","))
-        response_obj = get_paginated(mysql_string_start + "AND id_country_origin=%s AND id_region_origin=%s \
-                             AND id_city_origin=%s",
-                             selection_fields=near_ids,
-                             args=request.args,
-                             order_clause="ORDER BY id DESC",
-                             order_index_format="id <= %s",
-                             order_arg="max_id")
+        my_sql_string_end, from_location_ids = get_from_location_sql_string_end(
+           request.args["from_location"]
+        )
+        location_ids.extend(from_location_ids)
+        response_obj = get_paginated(
+          mysql_string_start + my_sql_string_end,
+          selection_fields=location_ids,
+          args=request.args,
+          order_clause="ORDER BY id DESC",
+          order_index_format="id <= %s",
+          order_arg="max_id"
+        )
     elif "language" in request.args:
-        near_ids.append(request.args["language"])
-        response_obj = get_paginated(mysql_string_start + "AND language_origin=%s",
-                             selection_fields=near_ids,
-                             args=request.args,
-                             order_clause="ORDER BY id DESC",
-                             order_index_format="id <= %s",
-                             order_arg="max_id")
+        location_ids.append(request.args["language"])
+        my_sql_string_end = "AND language_origin=%s"
+        response_obj = get_paginated(
+          mysql_string_start + my_sql_string_end,
+          selection_fields=location_ids,
+          args=request.args,
+          order_clause="ORDER BY id DESC",
+          order_index_format="id <= %s",
+          order_arg="max_id"
+        )
     else:
-        return make_response("No location/language query parameter", HTTPStatus.METHOD_NOT_ALLOWED)
+        return make_response(
+          "No location/language query parameter", HTTPStatus.METHOD_NOT_ALLOWED
+        )
     if len(response_obj.get_json()) == 0:
         # The network doesn't exist. So, let's make it!
         try:
             make_new_network(make_new_network_request())
             func_counter += 1
             if func_counter < 2:
-                # We need to avoid a stack overflow error if our make_new_network messes up.
+                # We need to avoid a stack overflow error
+                # if our make_new_network messes up.
                 return get_networks(func_counter)
         except (AttributeError, ValueError, IndexError, IntegrityError) as e:
             abort(HTTPStatus.BAD_REQUEST)

--- a/api/blueprints/networks/controllers.py
+++ b/api/blueprints/networks/controllers.py
@@ -113,14 +113,14 @@ def get_networks(func_counter=0):
           "No near_location specified", HTTPStatus.METHOD_NOT_ALLOWED
         )
 
-    location_ids = []
+    selection_fields = []
 
     # All requests will start with the same query and query for near_location.
     my_sql_string_start, near_location_ids = get_near_location_sql_string_start(
       request.args["near_location"]
     )
 
-    location_ids.extend(near_location_ids)
+    selection_fields.extend(near_location_ids)
 
     # Need to check if querying a location or language network.
     # That changes our queries.
@@ -128,21 +128,21 @@ def get_networks(func_counter=0):
         my_sql_string_end, from_location_ids = get_from_location_sql_string_end(
            request.args["from_location"]
         )
-        location_ids.extend(from_location_ids)
+        selection_fields.extend(from_location_ids)
         response_obj = get_paginated(
           my_sql_string_start + my_sql_string_end,
-          selection_fields=location_ids,
+          selection_fields=selection_fields,
           args=request.args,
           order_clause="ORDER BY id DESC",
           order_index_format="id <= %s",
           order_arg="max_id"
         )
     elif "language" in request.args:
-        location_ids.append(request.args["language"])
+        selection_fields.append(request.args["language"])
         my_sql_string_end = "AND language_origin=%s"
         response_obj = get_paginated(
           my_sql_string_start + my_sql_string_end,
-          selection_fields=location_ids,
+          selection_fields=selection_fields,
           args=request.args,
           order_clause="ORDER BY id DESC",
           order_index_format="id <= %s",

--- a/api/blueprints/networks/controllers.py
+++ b/api/blueprints/networks/controllers.py
@@ -130,7 +130,7 @@ def get_networks(func_counter=0):
         )
         location_ids.extend(from_location_ids)
         response_obj = get_paginated(
-          mysql_string_start + my_sql_string_end,
+          my_sql_string_start + my_sql_string_end,
           selection_fields=location_ids,
           args=request.args,
           order_clause="ORDER BY id DESC",
@@ -141,7 +141,7 @@ def get_networks(func_counter=0):
         location_ids.append(request.args["language"])
         my_sql_string_end = "AND language_origin=%s"
         response_obj = get_paginated(
-          mysql_string_start + my_sql_string_end,
+          my_sql_string_start + my_sql_string_end,
           selection_fields=location_ids,
           args=request.args,
           order_clause="ORDER BY id DESC",

--- a/api/blueprints/networks/controllers.py
+++ b/api/blueprints/networks/controllers.py
@@ -3,7 +3,8 @@ from api import require_apikey
 from api.apiutils import *
 from pymysql.err import IntegrityError
 
-from api.blueprints.networks.utils import get_from_location_sql_string_end
+from api.blueprints.networks.utils import get_from_location_sql_string_end, \
+  get_near_location_sql_string_start
 
 networks = Blueprint('network', __name__)
 

--- a/api/blueprints/networks/utils.py
+++ b/api/blueprints/networks/utils.py
@@ -1,0 +1,88 @@
+#
+# Utility functions for the networks API.
+#
+
+from flask import Blueprint, request, abort
+from http import HTTPStatus
+
+### Helpers for the GET networks function.
+
+def get_near_location_sql_string_start(near_location):
+    """Returns the first half of the SQL query string to use
+    for a GET networks call.
+
+    :param near_location: the query string passed into the request.
+    :return: (sql string format, values to include in sql string format)
+    """
+    near_location = near_location.split(",")
+    if len(near_location) != 3:
+        abort(HTTPStatus.BAD_REQUEST)
+
+    country_id, region_id, city_id = near_location
+
+    # Build string.
+    sql_string_start = "SELECT * FROM networks "
+
+    # If country id null?
+    if country_id == "-1" or country_id.lower() == "null":
+        sql_string_start += "WHERE id_country_cur is %s "
+        country_id = "NULL"
+    else:
+        sql_string_start += "WHERE id_country_cur=%s "
+
+     # If region id null?
+    if region_id == "-1" or region_id.lower() == "null":
+        sql_string_start += "AND id_region_cur is %s "
+        region_id = "NULL"
+    else:
+        sql_string_start += "AND id_region_cur=%s "
+
+     # If city id null?
+    if city_id == "-1" or city_id.lower() == "null":
+        sql_string_start += "AND id_city_cur is %s "
+        city_id = "NULL"
+    else:
+        sql_string_start += "AND id_city_cur=%s "
+
+    return (sql_string_start, [country_id, region_id, city_id])
+
+def get_from_location_sql_string_end(from_location):
+    """Returns the second half of the SQL query string to use
+    for a GET networks call with from_location specified.
+
+    :param from_location: the query string passed into the request.
+    :return: (sql string format, values to include in sql string format)
+    """
+    from_location = from_location.split(",")
+    if len(from_location) != 3:
+        abort(HTTPStatus.BAD_REQUEST)
+
+    country_id, region_id, city_id = from_location
+
+    # Build string.
+    sql_string_end = ""
+
+    # If country id null?
+    if country_id == "-1" or country_id.lower() == "null":
+        sql_string_end += "AND id_country_origin is %s "
+        country_id = "NULL"
+    else:
+        sql_string_end += "AND id_country_origin=%s "
+
+     # If region id null?
+    if region_id == "-1" or region_id.lower() == "null":
+        sql_string_end += "AND id_region_origin is %s "
+        region_id = "NULL"
+    else:
+        sql_string_end += "AND id_region_origin=%s "
+
+     # If city id null?
+    if city_id == "-1" or city_id.lower() == "null":
+        sql_string_end += "AND id_city_origin is %s "
+        city_id = "NULL"
+    else:
+        sql_string_end += "AND id_city_origin=%s "
+
+    return (sql_string_end, [country_id, region_id, city_id])
+
+

--- a/api/blueprints/networks/utils.py
+++ b/api/blueprints/networks/utils.py
@@ -25,26 +25,29 @@ def get_near_location_sql_string_start(near_location):
 
     # If country id null?
     if country_id == "-1" or country_id.lower() == "null":
-        sql_string_start += "WHERE id_country_cur is %s "
-        country_id = "NULL"
+        sql_string_start += "WHERE id_country_cur is NULL "
+        country_id = None
     else:
         sql_string_start += "WHERE id_country_cur=%s "
 
      # If region id null?
     if region_id == "-1" or region_id.lower() == "null":
-        sql_string_start += "AND id_region_cur is %s "
-        region_id = "NULL"
+        sql_string_start += "AND id_region_cur is NULL "
+        region_id = None
     else:
         sql_string_start += "AND id_region_cur=%s "
 
      # If city id null?
     if city_id == "-1" or city_id.lower() == "null":
-        sql_string_start += "AND id_city_cur is %s "
-        city_id = "NULL"
+        sql_string_start += "AND id_city_cur is NULL "
+        city_id = None
     else:
         sql_string_start += "AND id_city_cur=%s "
 
-    return (sql_string_start, [country_id, region_id, city_id])
+    ids_to_return = [
+        id_ for id_ in [country_id, region_id, city_id] if id_
+    ]
+    return (sql_string_start, ids_to_return)
 
 def get_from_location_sql_string_end(from_location):
     """Returns the second half of the SQL query string to use
@@ -64,25 +67,26 @@ def get_from_location_sql_string_end(from_location):
 
     # If country id null?
     if country_id == "-1" or country_id.lower() == "null":
-        sql_string_end += "AND id_country_origin is %s "
-        country_id = "NULL"
+        sql_string_end += "AND id_country_origin is NULL "
+        country_id = None
     else:
         sql_string_end += "AND id_country_origin=%s "
 
      # If region id null?
     if region_id == "-1" or region_id.lower() == "null":
-        sql_string_end += "AND id_region_origin is %s "
-        region_id = "NULL"
+        sql_string_end += "AND id_region_origin is NULL "
+        region_id = None
     else:
         sql_string_end += "AND id_region_origin=%s "
 
      # If city id null?
     if city_id == "-1" or city_id.lower() == "null":
-        sql_string_end += "AND id_city_origin is %s "
-        city_id = "NULL"
+        sql_string_end += "AND id_city_origin is NULL "
+        city_id = None
     else:
         sql_string_end += "AND id_city_origin=%s "
 
-    return (sql_string_end, [country_id, region_id, city_id])
-
-
+    ids_to_return = [
+        id_ for id_ in [country_id, region_id, city_id] if id_
+    ]
+    return (sql_string_end, ids_to_return)


### PR DESCRIPTION
Two main bug fixes. 

- Main bug fix is that SQL POST fields that are `'null'` or `-1` actually get added as `NULL` fields in the database now.  Before if the field's value was the string `'null'`, then the string `'null'` would get added to the database, not the value `NULL`.  Same thing for integer values. 
- Another bug fix.  Before we were not able to find a network that had `NULL` values for some of its fields because the check was `field = 'null'`.  To check if a field is `NULL` while querying the database, we must use `field is NULL`.  
- Some improvements to code quality