### PR TITLE
Add security HTTP headers to API responses

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -31,3 +31,13 @@ api.register_blueprint(locations, url_prefix='/location')
 api.register_blueprint(languages, url_prefix='/language')
 api.register_blueprint(accounts, url_prefix='/account')
 api.register_blueprint(upload, url_prefix='/upload')
+
+@api.after_request
+def add_custom_http_response_headers(response):
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["Strict-Transport-Security"] = "max-age=86400; includeSubDomains"
+    response.headers["Expires"] = "Thu, 01 Jan 1970 00:00:00 GMT"
+    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate, max-age=0"
+    response.headers["Content-Security-Policy"] = "default-src 'self'"
+    response.headers["X-CultureMesh"] = "API"
+    return response


### PR DESCRIPTION
- Adds recommended security headers to every HTTP response from the CultureMesh API.  A couple of these (STS, CSP) really only make sense for websites (i.e. HTTP responses ingested by a browser), but I include them here in case that in the future some UI exists for the API.

```python
# Prevents rosetta flash attacks 
response.headers["X-Content-Type-Options"] = "nosniff"

# Enforces that resources requested from the API happen over HTTPS>
response.headers["Strict-Transport-Security"] = "max-age=86400; includeSubDomains"

# Make sure there is no intermediate caching of content
response.headers["Expires"] = "Thu, 01 Jan 1970 00:00:00 GMT"
response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate, max-age=0"

# See https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP.  Only makes sense for websites, but
# including here in case there's a UI in the future.
response.headers["Content-Security-Policy"] = "default-src 'self'"

# I added this header with "lite" for CultureMeshFFB.  It's good to have some ID on these.
response.headers["X-CultureMesh"] = "API"
```